### PR TITLE
add new heading pattern "I/E."

### DIFF
--- a/screenplay_pdf_to_json/utils/headingHelpers.py
+++ b/screenplay_pdf_to_json/utils/headingHelpers.py
@@ -1,6 +1,6 @@
 import re
 
-headingEnum = ["EXT./INT.", "EXT./INT.", "INT./EXT.", "EXT/INT","INT/EXT", "INT.", "EXT.", "INT --", "EXT --"]
+headingEnum = ["EXT./INT.", "EXT/INT.", "INT./EXT.", "EXT/INT","INT/EXT", "INT.", "EXT.", "INT --", "EXT --", "I/E."]
 
 
 def isHeading(content):
@@ -48,9 +48,10 @@ def extractHeading(text):
         INT.
         EXT --
         INT --
+        I/E.
     """
     region = re.search(
-        '((?:.* )?(?:EXT[\\.]?\\/INT[\\.]?|INT[\\.]?\\/EXT[\\.]?|INT(?:\\.| --)|EXT(?:\\.| --)))', text).groups()[0]
+        r'((?:.* )?(?:EXT[\.]?\/INT[\.]?|INT[\.]?\/EXT[\.]?|INT(?:\.| --)|EXT(?:\.| --)|I\/E\.))', text).groups()[0]
     time = extractTime(text)
 
 


### PR DESCRIPTION
Greetings,

I noticed that the 1st scene in the movie *A Man Called Otto (2022)* has a title started with `I/E.`. So I add the pattern into `screenplay_pdf_to_json/utils/headingHelpers.py`.

```
I/E. BUSY BEAVER HARDWARE STORE, 2018 - DAY

OUTSIDE - the words “BUSY BEAVER” are spelled out across the
front of the hardware store in bold letters.

INSIDE - OTTO (63, irascible) mutters his way through the
aisles. He picks out a large screw hook, examines various
kinds of rope. Finally settling on one, he measures five feet
and pulls out a pocket knife to cut it.

(rest omitted)
```

Please find the reference here: [Screenplay PDF of A Man Called Otto (2022)](https://assets.scriptslug.com/live/pdf/scripts/a-man-called-otto-2022.pdf).

I've run a test on 14 movies, which includes:

```
a-man-called-otto
aftersun
all-quiet-on-the-western-front
black-panther-wakanda-forever
living
the-banshees-of-inisherin
the-fabelmans
the-whale
the-woman-king
till
top-gun-maverick
triangle-of-sadness
white-noise
women-talking
```

and it showed none side effects.

Thank you for your attention and consideration.

Best regards,
Shunchi